### PR TITLE
Fix incorrect index links on portfolio pages

### DIFF
--- a/afrigarde.html
+++ b/afrigarde.html
@@ -12,13 +12,13 @@
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
-    <div class="logo"><a href="../index.html">MU</a></div>
+    <div class="logo"><a href="index.html">MU</a></div>
   </div>
 
   <nav id="mobileMenu" class="slideout">
     <div class="close-btn" onclick="toggleMenu()">×</div>
     <ul>
-      <li><a href="../index.html">About</a></li>
+      <li><a href="index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">

--- a/illustration.html
+++ b/illustration.html
@@ -12,12 +12,12 @@
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
-    <div class="logo"><a href="../index.html">MU</a></div>
+    <div class="logo"><a href="index.html">MU</a></div>
   </div>
   <nav id="mobileMenu" class="slideout">
     <div class="close-btn" onclick="toggleMenu()">×</div>
     <ul>
-      <li><a href="../index.html">About</a></li>
+      <li><a href="index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">

--- a/packaging-design.html
+++ b/packaging-design.html
@@ -13,12 +13,12 @@
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
-    <div class="logo"><a href="../index.html">MU</a></div>
+    <div class="logo"><a href="index.html">MU</a></div>
   </div>
   <nav id="mobileMenu" class="slideout">
     <div class="close-btn" onclick="toggleMenu()">×</div>
     <ul>
-      <li><a href="../index.html">About</a></li>
+      <li><a href="index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">

--- a/textile-design.html
+++ b/textile-design.html
@@ -12,12 +12,12 @@
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
-    <div class="logo"><a href="../index.html">MU</a></div>
+    <div class="logo"><a href="index.html">MU</a></div>
   </div>
   <nav id="mobileMenu" class="slideout">
     <div class="close-btn" onclick="toggleMenu()">×</div>
     <ul>
-      <li><a href="../index.html">About</a></li>
+      <li><a href="index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">


### PR DESCRIPTION
## Summary
- correct MU logo and About menu links to point to `index.html` on portfolio pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bb5b6b888321a46b20d47ab9d96b