### PR TITLE
Standardize portfolio submenu labels

### DIFF
--- a/afrigarde.html
+++ b/afrigarde.html
@@ -22,11 +22,11 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity and Logos</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
           <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>

--- a/art.html
+++ b/art.html
@@ -23,11 +23,11 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
   <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
   <ul class="portfolio-sub">
-  <li><a href="brand-identity.html">&bull; Brand Identity and Logos</a></li>
+  <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
   <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
   <li><a href="illustration.html">&bull; Illustration</a></li>
   <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
-  <li><a href="stylist.html">&bull; Stylist</a></li>
+  <li><a href="stylist.html">&bull; Styling</a></li>
   <li><a href="textile-design.html">&bull; Textile Design</a></li>
   </ul>
       </li>

--- a/brand-identity.html
+++ b/brand-identity.html
@@ -24,9 +24,9 @@
           <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/cv.html
+++ b/cv.html
@@ -23,9 +23,9 @@
           <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/graphic-design.html
+++ b/graphic-design.html
@@ -27,12 +27,12 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/illustration.html
+++ b/illustration.html
@@ -21,12 +21,12 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/packaging-design.html
+++ b/packaging-design.html
@@ -22,12 +22,12 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/stylist.html
+++ b/stylist.html
@@ -21,12 +21,12 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
-          <li><a href="packaging-design.html">&bull; Packaging</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
-          <li><a href="textile-design.html">&bull; Textile</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>

--- a/textile-design.html
+++ b/textile-design.html
@@ -21,11 +21,11 @@
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
         <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
         <ul class="portfolio-sub">
-          <li><a href="brand-identity.html">&bull; Brand Identity and Logos</a></li>
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
           <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
           <li><a href="illustration.html">&bull; Illustration</a></li>
           <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
-          <li><a href="stylist.html">&bull; Stylist</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>


### PR DESCRIPTION
## Summary
- Apply consistent portfolio submenu labels across site: Brand Identity & Logos, Graphic Design, Illustration, Packaging Design, Styling, and Textile Design
- Restore index.html to its original submenu text to avoid conflicts with external changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c220f3588321ae443a7da2157535