### PR TITLE
Use white background for all pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
-  background: linear-gradient(120deg, #ffe0f0, #f0e0ff);
+  background: #ffffff;
   padding: 0;
   user-select: none;
 }
@@ -351,12 +351,7 @@ html, body {
 }
 
 body.brand-identity {
-  background: radial-gradient(circle at 20% 40%, #ffe0f0 0%, transparent 30%),
-              radial-gradient(circle at 80% 60%, #f0e0ff 0%, transparent 30%),
-              radial-gradient(circle at 50% 90%, #fad0c4 0%, transparent 30%);
-  background-color: #ffffff;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
+  background: #ffffff;
 }
 
 /* ---------- Global gallery defaults ---------- */


### PR DESCRIPTION
## Summary
- Set global `body` background to white for a uniform look across pages
- Remove radial gradients so the Brand Identity page also uses a solid white background

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898c5c57c88832194b86461493de3a7