### PR TITLE
feat: add service worker for offline caching

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,3 +188,12 @@ function testURL(url, timeout = 8000) {
     console.warn('[Cloudinary skipped]', e);
   }
 })();
+
+// Register service worker for offline support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js').catch(err => {
+      console.warn('Service worker registration failed', err);
+    });
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'mariauys-site-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/afrigarde.html',
+  '/brand-identity.html',
+  '/graphic-design.html',
+  '/illustration.html',
+  '/packaging-design.html',
+  '/stylist.html',
+  '/textile-design.html',
+  '/art.html',
+  '/cv.html',
+  '/instagram-logo.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request).then(networkResponse => {
+        if (
+          event.request.method === 'GET' &&
+          networkResponse &&
+          networkResponse.status === 200 &&
+          networkResponse.type === 'basic'
+        ) {
+          const respClone = networkResponse.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, respClone));
+        }
+        return networkResponse;
+      }).catch(() => caches.match('/index.html'));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add service worker and cache key site assets
- register service worker for offline support across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898da1549f08321b63284e524197124