### PR TITLE
Use Google-hosted Poppins fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Portfolio of Maria Uys, designer and artist specializing in brand identity, packaging, illustration, textile design and styling." />
   <title>Maria Uys — Designer & Artist</title>
 
-  <!-- Fonts & CSS -->
+  <!-- Fonts & CSS (Google-hosted; binary font files not supported) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+/* Poppins via Google Fonts; binary font files omitted */
 /* Global styles */
 body {
   margin: 0;


### PR DESCRIPTION
## Summary
- revert inlined Poppins data and rely on Google Fonts instead
- document Google-hosted font usage due to binary file limitations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898dc7ce62483219972aec303d40c7e