### PR TITLE
Add features page for external links

### DIFF
--- a/afrigarde.html
+++ b/afrigarde.html
@@ -32,6 +32,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/art.html
+++ b/art.html
@@ -31,6 +31,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/brand-identity.html
+++ b/brand-identity.html
@@ -31,6 +31,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/cv.html
+++ b/cv.html
@@ -30,6 +30,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/features.html
+++ b/features.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="External articles and pages featuring Maria Uys." />
+  <title>Features | Maria Uys</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="features" oncontextmenu="return false;">
+  <div id="overlay" onclick="toggleMenu(event)"></div>
+  <div class="topbar">
+    <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
+    <div class="logo"><a href="index.html">MU</a></div>
+  </div>
+  <nav id="mobileMenu" class="slideout">
+    <div class="close-btn" onclick="toggleMenu()">×</div>
+    <ul>
+      <li><a href="index.html">About</a></li>
+      <li class="portfolio-toggle" onclick="toggleDropdown(this)">
+        <a href="#">Portfolio <span class="arrow">&#9662;</span></a>
+        <ul class="portfolio-sub">
+          <li><a href="brand-identity.html">&bull; Brand Identity & Logos</a></li>
+          <li><a href="graphic-design.html">&bull; Graphic Design</a></li>
+          <li><a href="illustration.html">&bull; Illustration</a></li>
+          <li><a href="packaging-design.html">&bull; Packaging Design</a></li>
+          <li><a href="stylist.html">&bull; Styling</a></li>
+          <li><a href="textile-design.html">&bull; Textile Design</a></li>
+        </ul>
+      </li>
+      <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
+      <li><a href="cv.html" class="cv-label">CV</a></li>
+      <li><a href="art.html">Art</a></li>
+    </ul>
+  </nav>
+
+  <main>
+    <h1>Features</h1>
+    <p class="feature-intro">Articles and external pages featuring Maria.</p>
+    <section class="features-list">
+      <a class="feature" href="https://www.designindaba.com/articles/creative-work/every-surface-canvas" target="_blank" rel="noopener">
+        <img src="features/design-indaba-canvas.svg" alt="Every Surface a Canvas thumbnail" />
+        <span>Every Surface a Canvas – Design Indaba</span>
+      </a>
+
+      <a class="feature" href="https://artsandculture.google.com/asset/maria-uys-is-a-cape-town-based-surface-designer-and-a-2015-emerging-creative-maria-uys/5AGnWt3a2Ib_tA" target="_blank" rel="noopener">
+        <img src="features/google-arts.svg" alt="Google Arts &amp; Culture feature thumbnail" />
+        <span>Google Arts &amp; Culture Feature</span>
+      </a>
+
+      <a class="feature" href="https://www.designindaba.com/articles/roundup/focus-south-african-designers-working-wool" target="_blank" rel="noopener">
+        <img src="features/design-indaba-wool.svg" alt="Designers Working with Wool thumbnail" />
+        <span>South African Designers Working with Wool – Design Indaba</span>
+      </a>
+
+      <a class="feature" href="https://www.designindaba.com/events/design-indaba-expo-2015" target="_blank" rel="noopener">
+        <img src="features/design-indaba-expo.svg" alt="Design Indaba Expo 2015 thumbnail" />
+        <span>Design Indaba Expo 2015</span>
+      </a>
+
+      <a class="feature" href="https://visi.co.za/design-indaba-2015-40-emerging-creatives/" target="_blank" rel="noopener">
+        <img src="features/visi.svg" alt="VISI article thumbnail" />
+        <span>VISI: 40 Emerging Creatives</span>
+      </a>
+
+      <a class="feature" href="https://thelivinghabitat.com/the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/" target="_blank" rel="noopener">
+        <img src="features/living-habitat.svg" alt="The Living Habitat article thumbnail" />
+        <span>The Living Habitat: Emerging Creatives Hunt</span>
+      </a>
+
+      <a class="feature" href="https://www.sadecor.co.za/interior-design-blog/events/design-indaba-the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/" target="_blank" rel="noopener">
+        <img src="features/sadecor.svg" alt="SA Décor &amp; Design article thumbnail" />
+        <span>SA Décor &amp; Design: Emerging Creatives</span>
+      </a>
+
+      <a class="feature" href="https://www.topbilling.com/articles/Shining-the-spotlight-on-the-women-behind-Afrigarde.html?articleID=3090" target="_blank" rel="noopener">
+        <img src="features/topbilling.svg" alt="Top Billing Afrigarde article thumbnail" />
+        <span>Top Billing: Afrigarde Spotlight</span>
+      </a>
+
+      <a class="feature" href="https://www.topbilling.com/Print-Friendly.php?url=%2Farticles%2FShining-the-spotlight-on-the-women-behind-Afrigarde.html%3FarticleID%3D3090" target="_blank" rel="noopener">
+        <img src="features/topbilling-print.svg" alt="Top Billing Afrigarde print thumbnail" />
+        <span>Top Billing: Afrigarde (Print)</span>
+      </a>
+
+      <a class="feature" href="https://www.youtube.com/watch?v=LU5vfaBzK7s" target="_blank" rel="noopener">
+        <img src="features/youtube-interview.svg" alt="YouTube interview thumbnail" />
+        <span>YouTube: Afrigarde Interview</span>
+      </a>
+
+      <a class="feature" href="https://www.behance.net/gallery/79721463/AFRIGARDE-2019" target="_blank" rel="noopener">
+        <img src="features/behance.svg" alt="Behance project thumbnail" />
+        <span>Behance: AFRIGARDE 2019</span>
+      </a>
+
+      <a class="feature" href="https://m.youtube.com/shorts/c7KqIpFRUcg" target="_blank" rel="noopener">
+        <img src="features/youtube-shorts.svg" alt="YouTube Shorts thumbnail" />
+        <span>YouTube Shorts: Afrigarde</span>
+      </a>
+    </section>
+  </main>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/features/behance.svg
+++ b/features/behance.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Behance</text>
+</svg>

--- a/features/design-indaba-canvas.svg
+++ b/features/design-indaba-canvas.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Design Indaba</text>
+</svg>

--- a/features/design-indaba-expo.svg
+++ b/features/design-indaba-expo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Design Indaba</text>
+</svg>

--- a/features/design-indaba-wool.svg
+++ b/features/design-indaba-wool.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Design Indaba</text>
+</svg>

--- a/features/google-arts.svg
+++ b/features/google-arts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Google Arts & Culture</text>
+</svg>

--- a/features/living-habitat.svg
+++ b/features/living-habitat.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">The Living Habitat</text>
+</svg>

--- a/features/sadecor.svg
+++ b/features/sadecor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">SA Décor & Design</text>
+</svg>

--- a/features/topbilling-print.svg
+++ b/features/topbilling-print.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Top Billing</text>
+</svg>

--- a/features/topbilling.svg
+++ b/features/topbilling.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">Top Billing</text>
+</svg>

--- a/features/visi.svg
+++ b/features/visi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">VISI</text>
+</svg>

--- a/features/youtube-interview.svg
+++ b/features/youtube-interview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">YouTube</text>
+</svg>

--- a/features/youtube-shorts.svg
+++ b/features/youtube-shorts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#666">YouTube</text>
+</svg>

--- a/graphic-design.html
+++ b/graphic-design.html
@@ -37,6 +37,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/illustration.html
+++ b/illustration.html
@@ -31,6 +31,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/packaging-design.html
+++ b/packaging-design.html
@@ -32,6 +32,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,6 +8,7 @@
   <url><loc>https://mariauys.com/stylist.html</loc></url>
   <url><loc>https://mariauys.com/textile-design.html</loc></url>
   <url><loc>https://mariauys.com/afrigarde.html</loc></url>
+  <url><loc>https://mariauys.com/features.html</loc></url>
   <url><loc>https://mariauys.com/cv.html</loc></url>
   <url><loc>https://mariauys.com/art.html</loc></url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -907,3 +907,40 @@ body.home main { padding-top: 5rem; }
 /* ===== Scroll reveal ===== */
 .reveal { opacity: 0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease; }
 .reveal.in { opacity: 1; transform: translateY(0); }
+
+/* Features page */
+.features-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.feature {
+  text-decoration: none;
+  color: #444;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.feature img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0.5rem;
+  transition: transform 0.2s ease;
+}
+
+.feature:hover img {
+  transform: scale(1.02);
+}
+
+.feature span {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  text-align: center;
+}

--- a/stylist.html
+++ b/stylist.html
@@ -31,6 +31,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
       <li><a href="art.html">Art</a></li>
     </ul>

--- a/textile-design.html
+++ b/textile-design.html
@@ -31,6 +31,7 @@
         </ul>
       </li>
       <li><a href="afrigarde.html">Afrigarde</a></li>
+      <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
       <li><a href="art.html">Art</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- Use local SVG placeholders for external feature previews so images load consistently
- Ensure feature captions sit below thumbnails with updated styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898cfcf69ec8321be0a3c8e0037faaf