### PR TITLE
Fix image stretching by respecting original dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,14 @@ body {
   user-select: none;
 }
 
+/* Ensure images scale down to fit but never exceed their original size */
+img {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100vh;
+}
+
 /* Topbar */
 .topbar {
   display: flex;
@@ -904,7 +912,11 @@ body.home main { padding-top: 5rem; }
   box-shadow: 0 16px 36px rgba(0,0,0,.10);
 }
 .cards .card img {
-  display: block; width: 100%; height: 260px; object-fit: cover;
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 260px;
 }
 .cards .card h3 {
   position: absolute; left: 0; right: 0; bottom: 0;
@@ -919,7 +931,7 @@ body.home main { padding-top: 5rem; }
     grid-column: span 12; /* 1-up on mobile */
   }
   .cards .card img {
-    height: 220px;
+    max-height: 220px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure images scale down responsively without exceeding their natural size
- Prevent card thumbnails from stretching by using auto dimensions and max-height limits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898efcfcfe883219453ec87682c1c9d