### PR TITLE
Hide Afrigarde and Art pages

### DIFF
--- a/archived/afrigarde.html
+++ b/archived/afrigarde.html
@@ -31,10 +31,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/archived/art.html
+++ b/archived/art.html
@@ -30,10 +30,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/brand-identity.html
+++ b/brand-identity.html
@@ -30,10 +30,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/cv.html
+++ b/cv.html
@@ -29,10 +29,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/features.html
+++ b/features.html
@@ -29,10 +29,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/graphic-design.html
+++ b/graphic-design.html
@@ -36,10 +36,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/illustration.html
+++ b/illustration.html
@@ -30,10 +30,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -35,10 +35,8 @@
           <li><a href="textile-design.html">&bull; Textile</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/packaging-design.html
+++ b/packaging-design.html
@@ -31,10 +31,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,8 +7,6 @@
   <url><loc>https://mariauys.com/packaging-design.html</loc></url>
   <url><loc>https://mariauys.com/stylist.html</loc></url>
   <url><loc>https://mariauys.com/textile-design.html</loc></url>
-  <url><loc>https://mariauys.com/afrigarde.html</loc></url>
   <url><loc>https://mariauys.com/features.html</loc></url>
   <url><loc>https://mariauys.com/cv.html</loc></url>
-  <url><loc>https://mariauys.com/art.html</loc></url>
 </urlset>

--- a/stylist.html
+++ b/stylist.html
@@ -30,10 +30,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label">CV</a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 

--- a/sw.js
+++ b/sw.js
@@ -1,17 +1,15 @@
-const CACHE_NAME = 'mariauys-site-cache-v1';
+const CACHE_NAME = 'mariauys-site-cache-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/style.css',
   '/script.js',
-  '/afrigarde.html',
   '/brand-identity.html',
   '/graphic-design.html',
   '/illustration.html',
   '/packaging-design.html',
   '/stylist.html',
   '/textile-design.html',
-  '/art.html',
   '/cv.html',
   '/instagram-logo.svg'
 ];

--- a/textile-design.html
+++ b/textile-design.html
@@ -30,10 +30,8 @@
           <li><a href="textile-design.html">&bull; Textile Design</a></li>
         </ul>
       </li>
-      <li><a href="afrigarde.html">Afrigarde</a></li>
       <li><a href="features.html">Features</a></li>
       <li><a href="cv.html" class="cv-label"></a></li>
-      <li><a href="art.html">Art</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary
- Remove Afrigarde and Art links from site navigation and archive the pages
- Drop Afrigarde and Art from service worker cache and sitemap

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899007b67b88321a91cb756be1676bf