### PR TITLE
Fix lightbox function and enable default lazy loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -120,6 +120,8 @@ async function openLightbox(i) {
     lbImg.style.display = 'block';
     lbImg.src = raw; // will show broken icon if nothing works
   }
+  }
+
 function openLightboxFromPath(path) {
   gallerySources = [path];
   openLightbox(0);
@@ -179,6 +181,8 @@ function testURL(url, timeout = 8000) {
     const CDN_BASE = `https://res.cloudinary.com/${CLOUD}/image/fetch`;
 
     document.querySelectorAll('img').forEach(img => {
+      if (!img.hasAttribute('loading')) img.loading = 'lazy';
+      if (!img.hasAttribute('decoding')) img.decoding = 'async';
       if (img.hasAttribute('data-no-cdn')) return;
 
       const raw = img.getAttribute('data-src') || img.getAttribute('src');


### PR DESCRIPTION
## Summary
- Close the lightbox open function to restore hamburger menu and lightbox features
- Add default lazy-loading and async decoding to images to improve load times

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4a6ec5e08321aff4e598e32574c2