### PR TITLE
Fix header staying visible when scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,9 +20,8 @@ body {
   padding: 1rem;
   background: #ffffffcc;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  position: fixed;         /* Make it fixed */
+  position: sticky;        /* Keep header visible while scrolling */
   top: 0;
-  left: 0;
   width: 100%;
   z-index: 1001;
 }

--- a/style.css
+++ b/style.css
@@ -20,10 +20,8 @@ body {
   padding: 1rem;
   background: #ffffffcc;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  position: fixed; /* Keep header visible while scrolling */
+  position: sticky; /* Keep header visible while scrolling */
   top: 0;
-  left: 0;
-  width: 100%;
   z-index: 1001;
 }
 

--- a/style.css
+++ b/style.css
@@ -20,8 +20,9 @@ body {
   padding: 1rem;
   background: #ffffffcc;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  position: sticky;        /* Keep header visible while scrolling */
+  position: fixed; /* Keep header visible while scrolling */
   top: 0;
+  left: 0;
   width: 100%;
   z-index: 1001;
 }


### PR DESCRIPTION
## Summary
- make site header sticky so the hamburger menu remains visible as you scroll

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aee8de334832187675d670e69229b