### PR TITLE
fix: keep header visible while scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body {
   background-position: 0 0, 0% 50%;
   animation: gradientShift 8s ease infinite;
   filter: brightness(1.1);
-  padding: 0;
+  padding: 5rem 0 0;  /* Reserve space for fixed header */
   user-select: none;
 }
 
@@ -151,7 +151,7 @@ body {
 
 /* Main content */
 main {
-  padding: 5rem 2rem 2rem; /* Increased top padding to clear topbar */
+  padding: 0 2rem 2rem; /* Header offset moved to body */
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- ensure top padding on `body` so the fixed header is never obscured
- move content spacing from `main` to `body`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de73f9cc083218bdc13c294937c71