### PR TITLE
Replace div controls with accessible buttons

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -9,11 +9,11 @@
 <body class="{{ bodyClass }}" oncontextmenu="return false;">
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
-    <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
+    <button class="hamburger" type="button" aria-label="Open menu">&#9776;</button>
     <div class="logo"><a href="/index.html">MU</a></div>
   </div>
   <nav id="mobileMenu" class="slideout">
-    <div class="close-btn" onclick="toggleMenu()">×</div>
+    <button class="close-btn" type="button" aria-label="Close menu">×</button>
     <ul>
       <li><a href="/index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">
@@ -37,10 +37,10 @@
   </main>
 
   <div id="lightbox">
-    <div class="close-btn-lightbox">×</div>
-    <div class="nav-btn nav-left">‹</div>
+    <button class="close-btn-lightbox" type="button" aria-label="Close gallery">×</button>
+    <button class="nav-btn nav-left" type="button" aria-label="Previous image">‹</button>
     <canvas id="lightboxCanvas"></canvas>
-    <div class="nav-btn nav-right">›</div>
+    <button class="nav-btn nav-right" type="button" aria-label="Next image">›</button>
   </div>
 
   <footer class="social-footer">

--- a/script.js
+++ b/script.js
@@ -32,9 +32,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Controls
-  document.querySelector('.close-btn-lightbox')?.addEventListener('click', closeLightbox);
-  document.querySelector('.nav-left')?.addEventListener('click', () => navigate(-1));
-  document.querySelector('.nav-right')?.addEventListener('click', () => navigate(1));
+  const closeBtnLb = document.querySelector('button.close-btn-lightbox');
+  closeBtnLb?.addEventListener('click', closeLightbox);
+  closeBtnLb?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); closeLightbox(); }
+  });
+  const navLeft = document.querySelector('button.nav-left');
+  navLeft?.addEventListener('click', () => navigate(-1));
+  navLeft?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(-1); }
+  });
+  const navRight = document.querySelector('button.nav-right');
+  navRight?.addEventListener('click', () => navigate(1));
+  navRight?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(1); }
+  });
   lightbox?.addEventListener('click', e => { if (e.target === lightbox) closeLightbox(); });
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') closeLightbox();
@@ -54,10 +66,20 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('click', e => {
     const menu = document.getElementById('mobileMenu');
     const overlay = document.getElementById('overlay');
-    const ham = document.querySelector('.hamburger');
+    const ham = document.querySelector('button.hamburger');
     if (!menu.contains(e.target) && !ham.contains(e.target)) {
       menu.classList.remove('open'); overlay.style.display = 'none';
     }
+  });
+  const hamBtn = document.querySelector('button.hamburger');
+  hamBtn?.addEventListener('click', e => toggleMenu(e));
+  hamBtn?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') toggleMenu(e);
+  });
+  const closeBtn = document.querySelector('button.close-btn');
+  closeBtn?.addEventListener('click', e => toggleMenu(e));
+  closeBtn?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') toggleMenu(e);
   });
 
   // Mobile CV label

--- a/style.css
+++ b/style.css
@@ -30,10 +30,19 @@ body {
 
 
 .hamburger {
+  background: none;
+  border: none;
   font-size: 1.6rem;
   cursor: pointer;
   margin-right: 1rem;
   user-select: none;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
 }
 
 .logo a {
@@ -205,6 +214,8 @@ canvas {
   cursor: pointer;
   user-select: none;
   z-index: 2001;
+  background: none;
+  border: none;
 }
 
 .nav-left {
@@ -222,6 +233,8 @@ canvas {
   font-size: 2rem;
   color: white;
   cursor: pointer;
+  background: none;
+  border: none;
 }
 
 /* PDF iframe */


### PR DESCRIPTION
## Summary
- replace hamburger, close, and gallery navigation divs with `<button>` elements and add aria labels
- update script to target buttons and enable keyboard activation
- reset default button styling for menu and lightbox controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de7a5b2d88321b841c2fb47bc9fb2