### PR TITLE
Allow text selection and context menu

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -6,7 +6,7 @@
   <title>{{ title }}</title>
   <link rel="stylesheet" href="/style.css">
 </head>
-<body class="{{ bodyClass }}" oncontextmenu="return false;">
+<body class="{{ bodyClass }}">
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>

--- a/archived/afrigarde.html
+++ b/archived/afrigarde.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="dist/style.min.css" />
 </head>
 
-<body class="afrigarde" oncontextmenu="return false;">
+<body class="afrigarde">
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>

--- a/archived/art.html
+++ b/archived/art.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dist/style.min.css">
 </head>
-<body class="art" oncontextmenu="return false;">
+  <body class="art">
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
     <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>

--- a/style.css
+++ b/style.css
@@ -9,7 +9,6 @@ body {
   animation: gradientShift 8s ease infinite;
   filter: brightness(1.1);
   padding: 0;
-  user-select: none;
 }
 
 
@@ -33,7 +32,6 @@ body {
   font-size: 1.6rem;
   cursor: pointer;
   margin-right: 1rem;
-  user-select: none;
 }
 
 .logo a {
@@ -203,7 +201,6 @@ canvas {
   font-size: 2rem;
   color: white;
   cursor: pointer;
-  user-select: none;
   z-index: 2001;
 }
 


### PR DESCRIPTION
## Summary
- Remove `user-select: none` from global and UI styles
- Permit right-click by dropping `oncontextmenu` attributes

## Testing
- `npm run build`
- `node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args:['--no-sandbox']});
  const page = await browser.newPage();
  const path = 'file://' + process.cwd() + '/dist/index.html';
  await page.goto(path);
  const selectionText = await page.evaluate(() => {
    const p = document.createElement('p');
    p.textContent = 'SelectMe';
    document.body.appendChild(p);
    const range = document.createRange();
    range.selectNodeContents(p);
    const sel = window.getSelection();
    sel.removeAllRanges();
    sel.addRange(range);
    return sel.toString();
  });
  const contextMenuAllowed = await page.evaluate(() => {
    const event = new MouseEvent('contextmenu', {bubbles:true, cancelable:true});
    return document.body.dispatchEvent(event);
  });
  console.log('selection:', selectionText);
  console.log('contextmenu allowed:', contextMenuAllowed);
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689de7b434a483219c9c47106f80599e