### PR TITLE
feat: highlight focus for lightbox controls

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -37,10 +37,10 @@
   </main>
 
   <div id="lightbox">
-    <div class="close-btn-lightbox">×</div>
-    <div class="nav-btn nav-left">‹</div>
+    <button class="close-btn-lightbox" type="button" aria-label="Close lightbox">×</button>
+    <button class="nav-btn nav-left" type="button" aria-label="Previous image">‹</button>
     <canvas id="lightboxCanvas"></canvas>
-    <div class="nav-btn nav-right">›</div>
+    <button class="nav-btn nav-right" type="button" aria-label="Next image">›</button>
   </div>
 
   <footer class="social-footer">

--- a/style.css
+++ b/style.css
@@ -205,6 +205,9 @@ canvas {
   cursor: pointer;
   user-select: none;
   z-index: 2001;
+  background: transparent;
+  border: none;
+  padding: 0;
 }
 
 .nav-left {
@@ -222,6 +225,15 @@ canvas {
   font-size: 2rem;
   color: white;
   cursor: pointer;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.nav-btn:focus-visible,
+.close-btn-lightbox:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 4px;
 }
 
 /* PDF iframe */


### PR DESCRIPTION
## Summary
- add `:focus-visible` outline for lightbox navigation and close buttons
- switch lightbox controls to semantic buttons with accessible labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689de7fe2e2c83218a2efc19199e1706