### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -9,11 +9,11 @@
 <body class="{{ bodyClass }}" oncontextmenu="return false;">
   <div id="overlay" onclick="toggleMenu(event)"></div>
   <div class="topbar">
-    <div class="hamburger" onclick="toggleMenu(event)">&#9776;</div>
+    <button class="hamburger" aria-controls="mobileMenu" aria-expanded="false" onclick="toggleMenu(event)">&#9776;</button>
     <div class="logo"><a href="/index.html">MU</a></div>
   </div>
-  <nav id="mobileMenu" class="slideout">
-    <div class="close-btn" onclick="toggleMenu()">×</div>
+  <nav id="mobileMenu" class="slideout" aria-hidden="true">
+    <button class="close-btn" aria-label="Close menu" onclick="toggleMenu(event)">×</button>
     <ul>
       <li><a href="/index.html">About</a></li>
       <li class="portfolio-toggle" onclick="toggleDropdown(this)">

--- a/script.js
+++ b/script.js
@@ -2,9 +2,16 @@
 window.toggleMenu = function (e) {
   const menu = document.getElementById('mobileMenu');
   const overlay = document.getElementById('overlay');
+  const ham = document.querySelector('.hamburger');
   if (e?.target.closest('.portfolio-sub')) return;
-  menu.classList.toggle('open');
-  overlay.style.display = menu.classList.contains('open') ? 'block' : 'none';
+  const isOpen = menu.classList.toggle('open');
+  overlay.style.display = isOpen ? 'block' : 'none';
+  ham?.setAttribute('aria-expanded', String(isOpen));
+  menu.setAttribute('aria-hidden', String(!isOpen));
+  menu.querySelectorAll('a, .close-btn').forEach(el => {
+    if (isOpen) el.removeAttribute('tabindex');
+    else el.setAttribute('tabindex', '-1');
+  });
 };
 window.toggleDropdown = function (el) {
   el.classList.toggle('open');
@@ -43,20 +50,14 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Menu
-  window.toggleMenu = function (e) {
-    const menu = document.getElementById('mobileMenu');
-    const overlay = document.getElementById('overlay');
-    if (e?.target.closest('.portfolio-sub')) return;
-    menu.classList.toggle('open');
-    overlay.style.display = menu.classList.contains('open') ? 'block' : 'none';
-  };
-  window.toggleDropdown = el => el.classList.toggle('open');
+  const menu = document.getElementById('mobileMenu');
+  const ham = document.querySelector('.hamburger');
+  ham?.setAttribute('aria-expanded', 'false');
+  menu?.setAttribute('aria-hidden', 'true');
+  menu?.querySelectorAll('a, .close-btn').forEach(el => el.setAttribute('tabindex', '-1'));
   document.addEventListener('click', e => {
-    const menu = document.getElementById('mobileMenu');
-    const overlay = document.getElementById('overlay');
-    const ham = document.querySelector('.hamburger');
     if (!menu.contains(e.target) && !ham.contains(e.target)) {
-      menu.classList.remove('open'); overlay.style.display = 'none';
+      if (menu.classList.contains('open')) toggleMenu();
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -34,6 +34,15 @@ body {
   cursor: pointer;
   margin-right: 1rem;
   user-select: none;
+  background: none;
+  border: none;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.6rem;
 }
 
 .logo a {


### PR DESCRIPTION
## Summary
- Convert mobile menu close element into a button with an accessible label
- Toggle tabindex for all menu controls to maintain focusability only when menu is open
- Style the close button with neutral appearance to match existing look

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de7e8b8cc8321a48dfd049474e089