### PR TITLE
Add hidden admin link in layout

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -48,6 +48,7 @@
       <img src="/instagram-logo.svg" alt="Instagram">
     </a>
     <p class="credit">built by CheekyBuild</p>
+    <a href="/admin/" class="visually-hidden">Admin</a>
   </footer>
 
   <script src="/script.js"></script>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,18 @@
 /* Poppins via Google Fonts; binary font files omitted */
 /* Global styles */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
## Summary
- hide admin link in layout footer for keyboard accessibility
- define `.visually-hidden` utility class for screen-reader-only link

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e36e560f083219cc10e226ec8b190