### PR TITLE
Add Netlify Identity widget to CMS login

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <title>Content Manager</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Netlify Identity -->
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <!-- Decap (Netlify CMS) -->
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   </head>


### PR DESCRIPTION
## Summary
- load Netlify Identity widget before Decap CMS in admin index

## Testing
- `npm run build`
- `python3 -m http.server -d dist 8080` (curl http://localhost:8080/admin/)


------
https://chatgpt.com/codex/tasks/task_e_689f43a7b4248321b25ef428975277a7