### PR TITLE
Add Netlify Identity widget and admin redirect

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -52,5 +52,17 @@
   </footer>
 
   <script src="/script.js"></script>
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  <script>
+    if (window.netlifyIdentity) {
+      window.netlifyIdentity.on("init", user => {
+        if (!user) {
+          window.netlifyIdentity.on("login", () => {
+            document.location.href = "/admin/";
+          });
+        }
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Netlify Identity widget in site layout
- add login redirect to `/admin/`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f4805a44c83218cca2dd50fc6776f