### PR TITLE
Refactor content into structured front matter

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -33,6 +33,97 @@
   </nav>
 
   <main>
+    {% if hero_image %}
+      <section class="hero reveal">
+        <div class="hero-bg">
+          <img src="{{ hero_image }}" alt="{{ hero_alt or '' }}" loading="eager" decoding="async">
+        </div>
+        <div class="hero-copy">
+          <h1><span>{{ title }}</span></h1>
+          {% if tagline %}<p class="tagline">{{ tagline }}</p>{% endif %}
+          {% if hero_cta %}<a class="btn" href="{{ hero_cta.link }}">{{ hero_cta.text }}</a>{% endif %}
+        </div>
+      </section>
+    {% endif %}
+
+    {% if sections %}
+      {% for section in sections %}
+        {% if section.type == 'cards' %}
+          <section{% if section.id %} id="{{ section.id }}"{% endif %} class="cards">
+            {% for card in section.cards %}
+              <a class="card reveal" href="{{ card.link }}">
+                <img src="{{ card.image }}" alt="{{ card.title }}">
+                <h3>{{ card.title }}</h3>
+              </a>
+            {% endfor %}
+          </section>
+        {% elif section.type == 'features' %}
+          {% if section.intro %}<p class="feature-intro">{{ section.intro }}</p>{% endif %}
+          <section class="features-list">
+            {% for f in section.items %}
+              <a class="feature" href="{{ f.url }}" target="_blank" rel="noopener">
+                <img src="{{ f.image }}" alt="{{ f.caption }}">
+                <span>{{ f.caption }}</span>
+              </a>
+            {% endfor %}
+          </section>
+        {% elif section.type == 'gallery' %}
+          <section class="{{ section.class | default('project-grid') }}">
+            {% if section.intro_image %}
+              <div class="graphic-gif">
+                <img src="{{ section.intro_image }}" alt="{{ section.intro_alt }}">
+              </div>
+            {% endif %}
+            {% if section.intro_text %}
+              <div class="graphic-title"><p>{{ section.intro_text }}</p></div>
+            {% endif %}
+            {% for group in section.groups %}
+              {% if group.class %}<div class="{{ group.class }}">{% endif %}
+                {% if group.images %}
+                  {% for img in group.images %}
+                    <img src="{{ img.src }}" alt="{{ img.alt }}"{% if img.lightbox %} class="lightbox-trigger" data-src="{{ img.src }}"{% endif %}>
+                  {% endfor %}
+                {% endif %}
+                {% if group.text %}{{ group.text | safe }}{% endif %}
+              {% if group.class %}</div>{% endif %}
+              {% if group.description %}<p class="project-description">{{ group.description }}</p>{% endif %}
+              {% if group.subgroups %}
+                {% for sg in group.subgroups %}
+                  <div class="{{ sg.class }}">
+                    {% for img in sg.images %}
+                      <img src="{{ img.src }}" alt="{{ img.alt }}">
+                    {% endfor %}
+                  </div>
+                {% endfor %}
+              {% endif %}
+              {% if group.hr %}<hr>{% endif %}
+            {% endfor %}
+          </section>
+        {% elif section.type == 'projects' %}
+          <section class="project-grid">
+            {% for item in section.items %}
+              <div class="project-item">
+                {% if item.hero %}<div class="grid-full"><img src="{{ item.hero }}" alt="{{ item.hero_alt }}"></div>{% endif %}
+                {% if item.text %}<p class="project-text">{{ item.text | safe }}</p>{% endif %}
+                {% if item.subgroups %}
+                  {% for sg in item.subgroups %}
+                    <div class="{{ sg.class }}">
+                      {% for img in sg.images %}<img src="{{ img.src }}" alt="{{ img.alt }}">{% endfor %}
+                    </div>
+                  {% endfor %}
+                {% endif %}
+              </div>
+              {% if item.hr %}<hr>{% endif %}
+            {% endfor %}
+          </section>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% if pdf %}
+      <div id="cvContent" data-pdf="{{ pdf }}"></div>
+    {% endif %}
+
     {{ content | safe }}
   </main>
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -18,7 +18,63 @@ collections:
       - { label: "Body Class", name: "bodyClass", widget: "string", required: false }
       - { label: "Layout", name: "layout", widget: "hidden", default: "layout.njk" }
       - { label: "Permalink", name: "permalink", widget: "string", required: false }
-      - { label: "Main Content", name: "body", widget: "markdown" }
+      - { label: "Hero Image", name: "hero_image", widget: "image", required: false }
+      - { label: "Tagline", name: "tagline", widget: "string", required: false }
+      - label: "Sections"
+        name: "sections"
+        widget: "list"
+        required: false
+        fields:
+          - { label: "Type", name: "type", widget: "string" }
+          - { label: "ID", name: "id", widget: "string", required: false }
+          - label: "Cards"
+            name: "cards"
+            widget: "list"
+            required: false
+            fields:
+              - { label: "Title", name: "title", widget: "string" }
+              - { label: "Link", name: "link", widget: "string" }
+              - { label: "Image", name: "image", widget: "image" }
+          - label: "Items"
+            name: "items"
+            widget: "list"
+            required: false
+            fields:
+              - { label: "URL", name: "url", widget: "string", required: false }
+              - { label: "Image", name: "image", widget: "string", required: false }
+              - { label: "Caption", name: "caption", widget: "string", required: false }
+          - label: "Groups"
+            name: "groups"
+            widget: "list"
+            required: false
+            fields:
+              - { label: "Class", name: "class", widget: "string", required: false }
+              - label: "Images"
+                name: "images"
+                widget: "list"
+                required: false
+                fields:
+                  - { label: "Image", name: "src", widget: "image" }
+                  - { label: "Alt", name: "alt", widget: "string", required: false }
+                  - { label: "Lightbox", name: "lightbox", widget: "boolean", required: false }
+              - { label: "Description", name: "description", widget: "string", required: false }
+              - { label: "HR", name: "hr", widget: "boolean", required: false }
+              - label: "Subgroups"
+                name: "subgroups"
+                widget: "list"
+                required: false
+                fields:
+                  - { label: "Class", name: "class", widget: "string" }
+                  - label: "Images"
+                    name: "images"
+                    widget: "list"
+                    fields:
+                      - { label: "Image", name: "src", widget: "image" }
+                      - { label: "Alt", name: "alt", widget: "string", required: false }
+          - { label: "Intro Image", name: "intro_image", widget: "image", required: false }
+          - { label: "Intro Text", name: "intro_text", widget: "string", required: false }
+      - { label: "PDF", name: "pdf", widget: "file", required: false }
+      - { label: "Body", name: "body", widget: "markdown", required: false }
 
   # Optional: allow editors to upload portfolio images through the CMS UI.
   - name: "media"

--- a/content/about.md
+++ b/content/about.md
@@ -3,50 +3,28 @@ title: "Maria Uys — Designer & Artist"
 bodyClass: home
 layout: layout.njk
 permalink: "index.html"
+hero_image: portfolio/graphic-design/images/img1.gif
+tagline: "Brand Identity · Packaging · Illustration · Textile · Styling"
+sections:
+  - type: cards
+    id: work
+    cards:
+      - title: "Brand Identity"
+        link: "brand-identity.html"
+        image: portfolio/brand-identity/images/img3.jpg
+      - title: "Graphic Design"
+        link: "graphic-design.html"
+        image: portfolio/graphic-design/images/img2.jpg
+      - title: "Illustration"
+        link: "illustration.html"
+        image: portfolio/illustration/images/img1.jpg
+      - title: "Packaging"
+        link: "packaging-design.html"
+        image: portfolio/packaging-design/images/img1.jpg
+      - title: "Stylist"
+        link: "stylist.html"
+        image: portfolio/stylist/images/img1.jpg
+      - title: "Textile"
+        link: "textile-design.html"
+        image: portfolio/textile-design/images/img1.jpg
 ---
-<section class="hero reveal">
-  <div class="hero-bg">
-    <img src="portfolio/graphic-design/images/img1.gif" data-no-cdn alt="" aria-hidden="true" loading="eager" decoding="async" width="1191" height="842">
-  </div>
-  <div class="hero-copy">
-    <h1><span>Maria Uys</span></h1>
-    <p class="tagline">Brand Identity · Packaging · Illustration · Textile · Styling</p>
-    <a class="btn" href="#work">View the work ↓</a>
-  </div>
-</section>
-
-<section id="work" class="cards">
-  <a class="card reveal" href="brand-identity.html">
-    <img src="portfolio/brand-identity/images/img3.jpg" alt="Brand Identity" loading="lazy" decoding="async" width="2480" height="2480">
-    <h3>Brand Identity</h3>
-  </a>
-  <a class="card reveal" href="graphic-design.html">
-    <img src="portfolio/graphic-design/images/img2.jpg" alt="Graphic Design" loading="lazy" decoding="async" width="960" height="640">
-    <h3>Graphic Design</h3>
-  </a>
-  <a class="card reveal" href="illustration.html">
-    <img src="portfolio/illustration/images/img1.jpg" alt="Illustration" loading="lazy" decoding="async" width="3840" height="3840">
-    <h3>Illustration</h3>
-  </a>
-  <a class="card reveal" href="packaging-design.html">
-    <img src="portfolio/packaging-design/images/img1.jpg" alt="Packaging Design" loading="lazy" decoding="async" width="6633" height="3508">
-    <h3>Packaging</h3>
-  </a>
-  <a class="card reveal" href="stylist.html">
-    <img src="portfolio/stylist/images/img1.jpg" alt="Stylist" loading="lazy" decoding="async" width="1280" height="853">
-    <h3>Stylist</h3>
-  </a>
-  <a class="card reveal" href="textile-design.html">
-    <img src="portfolio/textile-design/images/img1.jpg" alt="Textile Design" loading="lazy" decoding="async" width="1200" height="849">
-    <h3>Textile</h3>
-  </a>
-</section>
-
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('in'); });
-    }, { threshold: 0.12 });
-    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
-  });
-</script>

--- a/content/brand-identity.md
+++ b/content/brand-identity.md
@@ -3,47 +3,51 @@ title: "Brand Identity"
 bodyClass: brand-identity
 layout: layout.njk
 permalink: "brand-identity.html"
+sections:
+  - type: gallery
+    groups:
+      - class: grid-two
+        images:
+          - src: portfolio/brand-identity/images/img1.jpg
+          - src: portfolio/brand-identity/images/img2.jpg
+      - description: "Concept & Logo design for SKNY New York"
+      - class: grid-full
+        images:
+          - src: portfolio/brand-identity/images/img3.jpg
+      - hr: true
+      - class: grid-full
+        images:
+          - src: portfolio/brand-identity/images/img4.jpg
+      - description: "Pep Active Concept — Logo & Product Details"
+      - class: grid-full
+        images:
+          - src: portfolio/brand-identity/images/img5.jpg
+      - hr: true
+      - class: grid-full
+        images:
+          - src: portfolio/brand-identity/images/img6.jpg
+      - description: "Pep Stationery Rebrand & Packaging Designs"
+      - class: grid-small
+        images:
+          - src: portfolio/brand-identity/images/img7.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img8.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img9.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img10.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img11.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img12.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img13.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img14.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img15.jpg
+            lightbox: true
+          - src: portfolio/brand-identity/images/img16.jpg
+            lightbox: true
+      - hr: true
 ---
-<h1>Brand Identity</h1>
-<section class="project-grid">
-  <div class="grid-two">
-    <img src="portfolio/brand-identity/images/img1.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img2.jpg" alt="">
-  </div>
-  <p class="project-description">
-    Concept & Logo design for SKNY New York
-  </p>
-  <div class="grid-full">
-    <img src="portfolio/brand-identity/images/img3.jpg" alt="">
-  </div>
-  <hr>
-  <div class="grid-full">
-    <img src="portfolio/brand-identity/images/img4.jpg" alt="">
-  </div>
-  <p class="project-description">
-    Pep Active Concept — Logo & Product Details
-  </p>
-  <div class="grid-full">
-    <img src="portfolio/brand-identity/images/img5.jpg" alt="">
-  </div>
-  <hr>
-  <div class="grid-full">
-    <img src="portfolio/brand-identity/images/img6.jpg" alt="">
-  </div>
-  <p class="project-description">
-    Pep Stationery Rebrand & Packaging Designs
-  </p>
-  <div class="grid-small">
-    <img src="portfolio/brand-identity/images/img7.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img7.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img8.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img8.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img9.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img9.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img10.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img10.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img11.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img11.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img12.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img12.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img13.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img13.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img14.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img14.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img15.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img15.jpg" alt="">
-    <img src="portfolio/brand-identity/images/img16.jpg" class="lightbox-trigger" data-src="portfolio/brand-identity/images/img16.jpg" alt="">
-  </div>
-  <hr>
-</section>

--- a/content/cv.md
+++ b/content/cv.md
@@ -3,28 +3,6 @@ title: "CV"
 bodyClass: cv-page
 layout: layout.njk
 permalink: "cv.html"
+pdf: portfolio/cv/Maria_Uys_CV.pdf
 ---
-<h1>CV</h1>
-<div id="cvContent"></div>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const isMobile = /Mobi|Android/i.test(navigator.userAgent);
-    const container = document.getElementById('cvContent');
-    const pdfPath = 'portfolio/cv/Maria_Uys_CV.pdf';
-    if (isMobile) {
-      const a = document.createElement('a');
-      a.href = pdfPath;
-      a.download = 'Maria_Uys_CV.pdf';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      container.innerHTML = `
-        <p class="cv-message">
-          Your download should begin shortly.<br><br>
-          <a href="${pdfPath}" download>Click here if it doesn’t</a>
-        </p>`;
-    } else {
-      container.innerHTML = `<iframe src="${pdfPath}" title="Maria Uys CV"></iframe>`;
-    }
-  });
-</script>
+# CV

--- a/content/features.md
+++ b/content/features.md
@@ -3,40 +3,32 @@ title: "Features"
 bodyClass: features
 layout: layout.njk
 permalink: "features.html"
+sections:
+  - type: features
+    intro: "Articles and external pages featuring Maria."
+    items:
+      - url: "https://www.designindaba.com/articles/creative-work/every-surface-canvas"
+        image: "https://s.wordpress.com/mshots/v1/https://www.designindaba.com/articles/creative-work/every-surface-canvas?w=600"
+        caption: "Every Surface a Canvas – Design Indaba"
+      - url: "https://artsandculture.google.com/asset/maria-uys-is-a-cape-town-based-surface-designer-and-a-2015-emerging-creative-maria-uys/5AGnWt3a2Ib_tA"
+        image: "https://s.wordpress.com/mshots/v1/https://artsandculture.google.com/asset/maria-uys-is-a-cape-town-based-surface-designer-and-a-2015-emerging-creative-maria-uys/5AGnWt3a2Ib_tA?w=600"
+        caption: "Google Arts & Culture Feature"
+      - url: "https://www.designindaba.com/articles/roundup/focus-south-african-designers-working-wool"
+        image: "https://s.wordpress.com/mshots/v1/https://www.designindaba.com/articles/roundup/focus-south-african-designers-working-wool?w=600"
+        caption: "South African Designers Working with Wool – Design Indaba"
+      - url: "https://www.designindaba.com/events/design-indaba-expo-2015"
+        image: "https://s.wordpress.com/mshots/v1/https://www.designindaba.com/events/design-indaba-expo-2015?w=600"
+        caption: "Design Indaba Expo 2015"
+      - url: "https://visi.co.za/design-indaba-2015-40-emerging-creatives/"
+        image: "https://s.wordpress.com/mshots/v1/https://visi.co.za/design-indaba-2015-40-emerging-creatives/?w=600"
+        caption: "VISI: 40 Emerging Creatives"
+      - url: "https://thelivinghabitat.com/the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/"
+        image: "https://s.wordpress.com/mshots/v1/https://thelivinghabitat.com/the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/?w=600"
+        caption: "The Living Habitat: Emerging Creatives Hunt"
+      - url: "https://www.sadecor.co.za/interior-design-blog/events/design-indaba-the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/"
+        image: "https://s.wordpress.com/mshots/v1/https://www.sadecor.co.za/interior-design-blog/events/design-indaba-the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/?w=600"
+        caption: "SA Décor & Design: Emerging Creatives"
+      - url: "https://www.topbilling.com/articles/Shining-the-spotlight-on-the-women-behind-Afrigarde.html?articleID=3090"
+        image: "https://s.wordpress.com/mshots/v1/https://www.topbilling.com/articles/Shining-the-spotlight-on-the-women-behind-Afrigarde.html?articleID=3090&w=600"
+        caption: "Top Billing: Afrigarde Spotlight"
 ---
-<h1>Features</h1>
-<p class="feature-intro">Articles and external pages featuring Maria.</p>
-<section class="features-list">
-  <a class="feature" href="https://www.designindaba.com/articles/creative-work/every-surface-canvas" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://www.designindaba.com/articles/creative-work/every-surface-canvas?w=600" alt="Every Surface a Canvas preview">
-    <span>Every Surface a Canvas – Design Indaba</span>
-  </a>
-  <a class="feature" href="https://artsandculture.google.com/asset/maria-uys-is-a-cape-town-based-surface-designer-and-a-2015-emerging-creative-maria-uys/5AGnWt3a2Ib_tA" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://artsandculture.google.com/asset/maria-uys-is-a-cape-town-based-surface-designer-and-a-2015-emerging-creative-maria-uys/5AGnWt3a2Ib_tA?w=600" alt="Google Arts &amp; Culture feature preview">
-    <span>Google Arts &amp; Culture Feature</span>
-  </a>
-  <a class="feature" href="https://www.designindaba.com/articles/roundup/focus-south-african-designers-working-wool" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://www.designindaba.com/articles/roundup/focus-south-african-designers-working-wool?w=600" alt="Designers working with wool preview">
-    <span>South African Designers Working with Wool – Design Indaba</span>
-  </a>
-  <a class="feature" href="https://www.designindaba.com/events/design-indaba-expo-2015" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://www.designindaba.com/events/design-indaba-expo-2015?w=600" alt="Design Indaba Expo 2015 preview">
-    <span>Design Indaba Expo 2015</span>
-  </a>
-  <a class="feature" href="https://visi.co.za/design-indaba-2015-40-emerging-creatives/" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://visi.co.za/design-indaba-2015-40-emerging-creatives/?w=600" alt="VISI 40 Emerging Creatives preview">
-    <span>VISI: 40 Emerging Creatives</span>
-  </a>
-  <a class="feature" href="https://thelivinghabitat.com/the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://thelivinghabitat.com/the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/?w=600" alt="The Living Habitat article preview">
-    <span>The Living Habitat: Emerging Creatives Hunt</span>
-  </a>
-  <a class="feature" href="https://www.sadecor.co.za/interior-design-blog/events/design-indaba-the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://www.sadecor.co.za/interior-design-blog/events/design-indaba-the-hunt-for-sas-hottest-young-emerging-creatives-has-begun/?w=600" alt="SA Décor and Design article preview">
-    <span>SA Décor &amp; Design: Emerging Creatives</span>
-  </a>
-  <a class="feature" href="https://www.topbilling.com/articles/Shining-the-spotlight-on-the-women-behind-Afrigarde.html?articleID=3090" target="_blank" rel="noopener">
-    <img src="https://s.wordpress.com/mshots/v1/https://www.topbilling.com/articles/Shining-the-spotlight-on-the-women-behind-Afrigarde.html?articleID=3090&amp;w=600" alt="Top Billing Afrigarde article preview">
-    <span>Top Billing: Afrigarde Spotlight</span>
-  </a>
-</section>

--- a/content/graphic-design.md
+++ b/content/graphic-design.md
@@ -3,39 +3,66 @@ title: "Graphic Design"
 bodyClass: graphic-design
 layout: layout.njk
 permalink: "graphic-design.html"
+sections:
+  - type: gallery
+    intro_image: portfolio/graphic-design/images/img1.gif
+    intro_alt: "Graphic design animation"
+    intro_text: "Logo Design"
+    groups:
+      - class: "graphic-gallery three-up"
+        images:
+          - src: portfolio/graphic-design/images/img2.jpg
+            alt: "Design 1"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img3.jpg
+            alt: "Design 2"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img4.jpg
+            alt: "Design 3"
+            lightbox: true
+        hr: true
+      - class: "graphic-gallery three-up"
+        images:
+          - src: portfolio/graphic-design/images/img5.jpg
+            alt: "Design 4"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img6.jpg
+            alt: "Design 5"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img7.jpg
+            alt: "Design 6"
+            lightbox: true
+        hr: true
+      - class: "graphic-gallery three-up"
+        images:
+          - src: portfolio/graphic-design/images/img8.jpg
+            alt: "Design 7"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img9.jpg
+            alt: "Design 8"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img10.png
+            alt: "Design 9"
+            lightbox: true
+        hr: true
+      - class: "graphic-gallery two-up"
+        images:
+          - src: portfolio/graphic-design/images/img11.jpg
+            alt: "Design 10"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img12.png
+            alt: "Design 11"
+            lightbox: true
+        hr: true
+      - class: "graphic-gallery three-up"
+        images:
+          - src: portfolio/graphic-design/images/img13.png
+            alt: "Design 12"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img14.png
+            alt: "Design 13"
+            lightbox: true
+          - src: portfolio/graphic-design/images/img15.png
+            alt: "Design 14"
+            lightbox: true
 ---
-<h1>Graphic Design</h1>
-<div class="graphic-gif">
-  <img src="portfolio/graphic-design/images/img1.gif" alt="Graphic design animation" loading="eager" decoding="async" width="1191" height="842">
-</div>
-<div class="graphic-title">
-  <p>Logo Design</p>
-</div>
-<section class="graphic-gallery three-up">
-  <img src="portfolio/graphic-design/images/img2.jpg" alt="Design 1" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img2.jpg" loading="lazy" decoding="async" width="960" height="640">
-  <img src="portfolio/graphic-design/images/img3.jpg" alt="Design 2" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img3.jpg" loading="lazy" decoding="async" width="842" height="1191">
-  <img src="portfolio/graphic-design/images/img4.jpg" alt="Design 3" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img4.jpg" loading="lazy" decoding="async" width="595" height="842">
-</section>
-<hr>
-<section class="graphic-gallery three-up">
-  <img src="portfolio/graphic-design/images/img5.jpg" alt="Design 4" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img5.jpg" loading="lazy" decoding="async" width="400" height="400">
-  <img src="portfolio/graphic-design/images/img6.jpg" alt="Design 5" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img6.jpg" loading="lazy" decoding="async" width="1200" height="1036">
-  <img src="portfolio/graphic-design/images/img7.jpg" alt="Design 6" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img7.jpg" loading="lazy" decoding="async" width="1200" height="1081">
-</section>
-<hr>
-<section class="graphic-gallery three-up">
-  <img src="portfolio/graphic-design/images/img8.jpg" alt="Design 7" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img8.jpg" loading="lazy" decoding="async" width="1000" height="1000">
-  <img src="portfolio/graphic-design/images/img9.jpg" alt="Design 8" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img9.jpg" loading="lazy" decoding="async" width="1920" height="1357">
-  <img src="portfolio/graphic-design/images/img10.png" alt="Design 9" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img10.png" loading="lazy" decoding="async" width="1004" height="1004">
-</section>
-<hr>
-<section class="graphic-gallery two-up">
-  <img src="portfolio/graphic-design/images/img11.jpg" alt="Design 10" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img11.jpg" loading="lazy" decoding="async" width="999" height="286">
-  <img src="portfolio/graphic-design/images/img12.png" alt="Design 11" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img12.png" loading="lazy" decoding="async" width="1920" height="864">
-</section>
-<hr>
-<section class="graphic-gallery three-up">
-  <img src="portfolio/graphic-design/images/img13.png" alt="Design 12" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img13.png" loading="lazy" decoding="async" width="1920" height="1419">
-  <img src="portfolio/graphic-design/images/img14.png" alt="Design 13" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img14.png" loading="lazy" decoding="async" width="1920" height="1421">
-  <img src="portfolio/graphic-design/images/img15.png" alt="Design 14" class="lightbox-trigger" data-src="portfolio/graphic-design/images/img15.png" loading="lazy" decoding="async" width="1920" height="2599">
-</section>

--- a/content/illustration.md
+++ b/content/illustration.md
@@ -3,46 +3,61 @@ title: "Illustration"
 bodyClass: illustration
 layout: layout.njk
 permalink: "illustration.html"
+sections:
+  - type: gallery
+    class: gallery
+    groups:
+      - class: gallery
+        images:
+          - src: portfolio/illustration/images/img1.jpg
+            alt: "Illustration 1"
+            lightbox: true
+          - src: portfolio/illustration/images/img2.jpg
+            alt: "Illustration 2"
+            lightbox: true
+          - src: portfolio/illustration/images/img3.jpg
+            alt: "Illustration 3"
+            lightbox: true
+          - src: portfolio/illustration/images/img4.jpg
+            alt: "Illustration 4"
+            lightbox: true
+          - src: portfolio/illustration/images/img5.jpg
+            alt: "Illustration 5"
+            lightbox: true
+          - src: portfolio/illustration/images/img6.jpg
+            alt: "Illustration 6"
+            lightbox: true
+          - src: portfolio/illustration/images/img7.jpg
+            alt: "Illustration 7"
+            lightbox: true
+          - src: portfolio/illustration/images/img8.jpg
+            alt: "Illustration 8"
+            lightbox: true
+          - src: portfolio/illustration/images/img9.jpg
+            alt: "Illustration 9"
+            lightbox: true
+          - src: portfolio/illustration/images/img10.jpg
+            alt: "Illustration 10"
+            lightbox: true
+          - src: portfolio/illustration/images/img11.jpg
+            alt: "Illustration 11"
+            lightbox: true
+          - src: portfolio/illustration/images/img12.jpg
+            alt: "Illustration 12"
+            lightbox: true
+          - src: portfolio/illustration/images/img13.jpg
+            alt: "Illustration 13"
+            lightbox: true
+          - src: portfolio/illustration/images/img14.jpg
+            alt: "Illustration 14"
+            lightbox: true
+          - src: portfolio/illustration/images/img15.jpg
+            alt: "Illustration 15"
+            lightbox: true
+          - src: portfolio/illustration/images/img16.png
+            alt: "Illustration 16"
+            lightbox: true
+          - src: portfolio/illustration/images/img17.png
+            alt: "Illustration 17"
+            lightbox: true
 ---
-<h1>Illustration</h1>
-<div class="gallery" id="gallery"></div>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const gallery = document.getElementById('gallery');
-  const exts = ['jpg','jpeg','png','gif','webp'];
-  let i = 1, misses = 0;
-  function tryNext(iLocal) {
-    let e = 0, found = false;
-    (function attempt() {
-      if (e >= exts.length) {
-        if (!found) misses++;
-        if (misses >= 2) return;
-        i++;
-        misses = misses;
-        tryNext(i);
-        return;
-      }
-      const path = `portfolio/illustration/images/img${i}.${exts[e]}`;
-      const test = new Image();
-        test.onload = () => {
-          found = true; misses = 0;
-          const thumb = document.createElement('img');
-          thumb.src = path;
-          thumb.alt = `Illustration ${i}`;
-          thumb.loading = 'lazy';
-          thumb.decoding = 'async';
-          thumb.style.width = '100%';
-          thumb.style.height = 'auto';
-          const index = gallerySources.push(path) - 1;
-          thumb.addEventListener('click', () => openLightbox(index));
-          gallery.appendChild(thumb);
-          i++;
-          tryNext(i);
-        };
-      test.onerror = () => { e++; attempt(); };
-      test.src = path;
-    })();
-  }
-  tryNext(i);
-});
-</script>

--- a/content/packaging-design.md
+++ b/content/packaging-design.md
@@ -3,47 +3,20 @@ title: "Packaging Design"
 bodyClass: packaging
 layout: layout.njk
 permalink: "packaging-design.html"
+sections:
+  - type: gallery
+    class: gallery
+    groups:
+      - class: gallery
+        images:
+          - src: portfolio/packaging-design/images/img1.jpg
+            alt: "Packaging 1"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/packaging-design/images/img2.jpg
+            alt: "Packaging 2"
+            lightbox: true
+        hr: true
 ---
-<h1>Packaging Design</h1>
-<div class="gallery" id="gallery"></div>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const gallery = document.getElementById('gallery');
-  const exts = ['jpg','jpeg','png','gif','webp'];
-  let i = 1, misses = 0;
-  function tryNext(iLocal) {
-    let e = 0, found = false;
-    (function attempt() {
-      if (e >= exts.length) {
-        if (!found) misses++;
-        if (misses >= 2) return;
-        i++;
-        tryNext(i);
-        return;
-      }
-      const path = `portfolio/packaging-design/images/img${i}.${exts[e]}`;
-      const test = new Image();
-        test.onload = () => {
-          found = true; misses = 0;
-          const thumb = document.createElement('img');
-          thumb.src = path;
-          thumb.alt = `Packaging ${i}`;
-          thumb.loading = 'lazy';
-          thumb.decoding = 'async';
-          thumb.style.width = '100%';
-          thumb.style.height = 'auto';
-          const index = gallerySources.push(path) - 1;
-          thumb.addEventListener('click', () => openLightbox(index));
-          gallery.appendChild(thumb);
-          const hr = document.createElement('hr');
-          gallery.appendChild(hr);
-          i++;
-          tryNext(i);
-        };
-      test.onerror = () => { e++; attempt(); };
-      test.src = path;
-    })();
-  }
-  tryNext(i);
-});
-</script>

--- a/content/stylist.md
+++ b/content/stylist.md
@@ -3,112 +3,75 @@ title: "Stylist"
 bodyClass: stylist
 layout: layout.njk
 permalink: "stylist.html"
+sections:
+  - type: projects
+    items:
+      - hero: portfolio/stylist/images/img1.jpg
+        text: "Grethe Rosseau for Afrigarde<br>Stylist: Maria Uys<br>MUA: Gareth Coleman"
+        subgroups:
+          - class: grid-two
+            images:
+              - src: portfolio/stylist/images/img2.jpg
+                alt: "Project 1 – Detail 1"
+              - src: portfolio/stylist/images/img3.jpg
+                alt: "Project 1 – Detail 2"
+        hr: true
+      - hero: portfolio/stylist/images/img4.jpg
+        text: "Grethe Rosseau for Afrigarde<br>Stylist: Del Lombard<br>MUA: Cecilia Fourie"
+        subgroups:
+          - class: grid-two
+            images:
+              - src: portfolio/stylist/images/img5.jpg
+                alt: "Project 2 – Detail 1"
+              - src: portfolio/stylist/images/img6.jpg
+                alt: "Project 2 – Detail 2"
+        hr: true
+      - hero: portfolio/stylist/images/img7.jpg
+        text: "Jurgen Hoffman for Sketchers<br>Stylist: Maria Uys<br>MUA: Eric Schmidt-Mohan"
+        subgroups:
+          - class: grid-three
+            images:
+              - src: portfolio/stylist/images/img8.jpg
+                alt: "Project 3 – 1"
+              - src: portfolio/stylist/images/img9.jpg
+                alt: "Project 3 – 2"
+              - src: portfolio/stylist/images/img10.jpg
+                alt: "Project 3 – 3"
+        hr: true
+      - hero: portfolio/stylist/images/img11.jpg
+        text: "Grethe Rosseau for Kat van Duinen<br>Stylist: Maria Uys<br>MUA: Sam Ellenberger"
+        subgroups:
+          - class: grid-two
+            images:
+              - src: portfolio/stylist/images/img12.jpg
+                alt: "Project 4 – 1"
+              - src: portfolio/stylist/images/img13.jpg
+                alt: "Project 4 – 2"
+        hr: true
+      - hero: portfolio/stylist/images/img14.jpg
+        text: "Dylan Louw for Afrigarde<br>Stylist: Maria Uys<br>MUA: Gareth Coleman"
+        hr: true
+      - hero: portfolio/stylist/images/img15.png
+        text: "Jurgen Hoffman for Sketchers<br>Stylist: Maria Uys<br>MUA: Eric Schmidt-Mohan"
+        subgroups:
+          - class: "grid-three grid-three--spaced"
+            images:
+              - src: portfolio/stylist/images/img16.jpg
+              - src: portfolio/stylist/images/img17.jpg
+              - src: portfolio/stylist/images/img18.jpg
+          - class: "grid-three grid-three--spaced"
+            images:
+              - src: portfolio/stylist/images/img19.jpg
+              - src: portfolio/stylist/images/img20.jpg
+              - src: portfolio/stylist/images/img21.jpg
+        hr: true
+      - hero: portfolio/stylist/images/img22.png
+        text: "Christina Colson for Grethe Rosseau<br>Stylist: Maria Uys<br>MUA: Sam Ellenberger"
+        subgroups:
+          - class: grid-four
+            images:
+              - src: portfolio/stylist/images/img23.jpg
+              - src: portfolio/stylist/images/img24.jpg
+              - src: portfolio/stylist/images/img25.jpg
+              - src: portfolio/stylist/images/img26.jpg
 ---
-<h1>Stylist</h1>
-<section class="project-grid">
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img1.jpg" alt="Project 1" width="1280" height="853">
-    </div>
-    <p class="project-text">
-      Grethe Rosseau for Afrigarde<br>
-      Stylist: Maria Uys<br>
-      MUA: Gareth Coleman
-    </p>
-    <div class="grid-two">
-      <img src="portfolio/stylist/images/img2.jpg" alt="Project 1 – Detail 1" width="853" height="1280">
-      <img src="portfolio/stylist/images/img3.jpg" alt="Project 1 – Detail 2" width="854" height="1280">
-    </div>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img4.jpg" alt="Project 2" width="3931" height="2621">
-    </div>
-    <p class="project-text">
-      Grethe Rosseau for Afrigarde<br>
-      Stylist: Del Lombard<br>
-      MUA: Cecilia Fourie
-    </p>
-    <div class="grid-two">
-      <img src="portfolio/stylist/images/img5.jpg" alt="Project 2 – Detail 1" width="1920" height="2880">
-      <img src="portfolio/stylist/images/img6.jpg" alt="Project 2 – Detail 2" width="1920" height="1280">
-    </div>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img7.jpg" alt="Project 3" width="1080" height="719">
-    </div>
-    <p class="project-text">
-      Jurgen Hoffman for Sketchers<br>
-      Stylist: Maria Uys<br>
-      MUA: Eric Schmidt-Mohan
-    </p>
-    <div class="grid-three">
-      <img src="portfolio/stylist/images/img8.jpg" alt="Project 3 – 1" width="1080" height="1080">
-      <img src="portfolio/stylist/images/img9.jpg" alt="Project 3 – 2" width="1080" height="1079">
-      <img src="portfolio/stylist/images/img10.jpg" alt="Project 3 – 3" width="1080" height="1080">
-    </div>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img11.jpg" alt="Project 4" width="1280" height="853">
-    </div>
-    <p class="project-text">
-      Grethe Rosseau for Kat van Duinen<br>
-      Stylist: Maria Uys<br>
-      MUA: Sam Ellenberger
-    </p>
-    <div class="grid-two">
-      <img src="portfolio/stylist/images/img12.jpg" alt="Project 4 – 1" width="854" height="1280">
-      <img src="portfolio/stylist/images/img13.jpg" alt="Project 4 – 2" width="853" height="1280">
-    </div>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img14.jpg" alt="Project 5" width="6016" height="4016">
-    </div>
-    <p class="project-text">
-      Dylan Louw for Afrigarde<br>
-      Stylist: Maria Uys<br>
-      MUA: Gareth Coleman
-    </p>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img15.png" alt="" width="2783" height="1856">
-    </div>
-    <div class="grid-three grid-three--spaced">
-      <img src="portfolio/stylist/images/img16.jpg" alt="" onerror="this.onerror=null;this.src='portfolio/stylist/images/img16.png'" width="1080" height="1079">
-      <img src="portfolio/stylist/images/img17.jpg" alt="" onerror="this.onerror=null;this.src='portfolio/stylist/images/img17.png'" width="1080" height="1079">
-      <img src="portfolio/stylist/images/img18.jpg" alt="" width="1080" height="1079">
-    </div>
-    <p class="project-text">Jurgen Hoffman for Sketchers<br>Stylist: Maria Uys<br>MUA: Eric Schmidt-Mohan</p>
-    <div class="grid-three grid-three--spaced">
-      <img src="portfolio/stylist/images/img19.jpg" alt="" width="1080" height="1079">
-      <img src="portfolio/stylist/images/img20.jpg" alt="" width="1080" height="1079">
-      <img src="portfolio/stylist/images/img21.jpg" alt="" width="1080" height="1079">
-    </div>
-  </div>
-  <hr>
-  <div class="project-item">
-    <div class="grid-full">
-      <img src="portfolio/stylist/images/img22.png" alt="Project 7" width="3508" height="2695">
-    </div>
-    <p class="project-text">
-      Christina Colson for Grethe Rosseau<br>
-      Stylist: Maria Uys<br>
-      MUA: Sam Ellenberger
-    </p>
-    <div class="grid-four">
-      <img src="portfolio/stylist/images/img23.jpg" alt="Project 7 – 1" width="854" height="1280">
-      <img src="portfolio/stylist/images/img24.jpg" alt="Project 7 – 2" width="854" height="1280">
-      <img src="portfolio/stylist/images/img25.jpg" alt="Project 7 – 3" width="853" height="1280">
-      <img src="portfolio/stylist/images/img26.jpg" alt="Project 7 – 4" width="853" height="1280">
-    </div>
-  </div>
-</section>

--- a/content/textile-design.md
+++ b/content/textile-design.md
@@ -3,36 +3,44 @@ title: "Textile Design"
 bodyClass: textile
 layout: layout.njk
 permalink: "textile-design.html"
+sections:
+  - type: gallery
+    class: gallery
+    groups:
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img1.jpg
+            alt: "Textile 1"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img2.jpg
+            alt: "Textile 2"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img3.jpg
+            alt: "Textile 3"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img4.jpg
+            alt: "Textile 4"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img5.jpg
+            alt: "Textile 5"
+            lightbox: true
+        hr: true
+      - class: gallery
+        images:
+          - src: portfolio/textile-design/images/img6.jpg
+            alt: "Textile 6"
+            lightbox: true
+        hr: true
 ---
-<h1>Textile Design</h1>
-<div class="gallery" id="gallery"></div>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const gallery = document.getElementById('gallery');
-  const exts = ['jpg','jpeg','png','gif'];
-  let idx = 1;
-  function tryLoad() {
-    let e = 0, img = new Image();
-    (function attempt() {
-      if (e >= exts.length) return;
-      img.src = `portfolio/textile-design/images/img${idx}.${exts[e]}`;
-      img.onload = () => {
-        const c = document.createElement('canvas');
-        const ctx = c.getContext('2d');
-        c.width = img.naturalWidth;
-        c.height = img.naturalHeight;
-        c.style.width = '100%';
-        c.style.height = 'auto';
-        ctx.drawImage(img, 0, 0, c.width, c.height);
-        gallery.appendChild(c);
-        const hr = document.createElement('hr');
-        gallery.appendChild(hr);
-        idx++;
-        tryLoad();
-      };
-      img.onerror = () => { e++; attempt(); };
-    })();
-  }
-  tryLoad();
-});
-</script>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,12 @@ let gallerySources = []; // raw URLs from the page (data-src or src)
 document.addEventListener('DOMContentLoaded', () => {
   lightbox = document.getElementById('lightbox');
 
+  // Reveal animations
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('in'); });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+
   // Add a real <img> inside the lightbox (we'll ignore the <canvas>)
   let lbImg = document.getElementById('lightboxImg');
   if (!lbImg && lightbox) {
@@ -85,6 +91,24 @@ document.addEventListener('DOMContentLoaded', () => {
   // Mobile CV label
   const cvLink = document.querySelector('.cv-label');
   if (cvLink) cvLink.textContent = /Mobi|Android/i.test(navigator.userAgent) ? 'Download CV' : 'CV';
+
+  // CV embed/download
+  const cvContent = document.getElementById('cvContent');
+  if (cvContent) {
+    const pdfPath = cvContent.dataset.pdf;
+    const isMobile = /Mobi|Android/i.test(navigator.userAgent);
+    if (isMobile) {
+      const a = document.createElement('a');
+      a.href = pdfPath;
+      a.download = pdfPath.split('/').pop();
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      cvContent.innerHTML = `<p class="cv-message">Your download should begin shortly.<br><br><a href="${pdfPath}" download>Click here if it doesn't</a></p>`;
+    } else {
+      cvContent.innerHTML = `<iframe src="${pdfPath}" title="Maria Uys CV"></iframe>`;
+    }
+  }
 
   // ---- Bind ALL lightbox triggers on the page ----
   wireTriggers('.lightbox-trigger');


### PR DESCRIPTION
## Summary
- restructure all pages to use front-matter fields for hero images, sections, galleries, and media links
- update layout to render new structured data and support CV embeds and reveal animations
- configure Netlify CMS with matching widgets and move inline scripts to script.js

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f52dc72588321bf403890b67a9898