### PR TITLE
fix: configure cms media folder and add media entry

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,8 +2,8 @@ backend:
   name: git-gateway
   branch: main          # change to your default branch if not "main"
 
-media_folder: "static/uploads"      # images saved in repo
-public_folder: "/static/uploads"    # how they’re referenced on the site
+media_folder: "portfolio/media"      # images saved in repo
+public_folder: "/portfolio/media"    # how they’re referenced on the site
 
 # Collections define editable content types in the CMS.
 collections:
@@ -79,8 +79,9 @@ collections:
   # Optional: allow editors to upload portfolio images through the CMS UI.
   - name: "media"
     label: "Portfolio Media"
-    folder: "portfolio"
+    folder: "portfolio/media"
     create: true
+    extension: "json"
     fields:
       - { label: "Image", name: "image", widget: "image" }
       - { label: "Alt Text", name: "alt", widget: "string", required: false }

--- a/portfolio/media/sample.json
+++ b/portfolio/media/sample.json
@@ -1,0 +1,4 @@
+{
+  "image": "afrigarde/images/img1.jpg",
+  "alt": "Sample portfolio media"
+}


### PR DESCRIPTION
## Summary
- point Netlify CMS media folder to existing `portfolio/media`
- store Portfolio Media entries as JSON and add sample entry

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5a896ebc8321a2d3ab085d334b75