### PR TITLE
Fix illustration gallery image overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -479,6 +479,11 @@ body.packaging .gallery hr {
   }
 }
 
+/* Flatten nested gallery wrappers so inner content spans full width */
+body .gallery > .gallery {
+  display: contents;
+}
+
 /* Lightbox background always dark */
 #lightbox {
   background: rgba(0,0,0,0.9) !important;


### PR DESCRIPTION
## Summary
- Ensure gallery images scale to their grid cells to prevent overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9d697434832183891d88e04bd6c4