### PR TITLE
Add carousel to home page

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -49,7 +49,13 @@
 
     {% if sections %}
       {% for section in sections %}
-        {% if section.type == 'cards' %}
+        {% if section.type == 'carousel' %}
+          <section{% if section.id %} id="{{ section.id }}"{% endif %} class="carousel">
+            {% for item in section.items %}
+              <img src="{{ item.src }}" alt="{{ item.alt }}">
+            {% endfor %}
+          </section>
+        {% elif section.type == 'cards' %}
           <section{% if section.id %} id="{{ section.id }}"{% endif %} class="cards">
             {% for card in section.cards %}
               <a class="card reveal" href="{{ card.link }}">

--- a/content/about.md
+++ b/content/about.md
@@ -6,27 +6,20 @@ permalink: "index.html"
 hero_image: portfolio/graphic-design/images/img1.gif
 tagline: "Brand Identity · Packaging · Illustration · Textile · Styling"
 sections:
-  - type: cards
-    id: work
-    cards:
-      - title: "Brand Identity"
-        link: "brand-identity.html"
-        image: portfolio/brand-identity/images/img3.jpg
-      - title: "Graphic Design"
-        link: "graphic-design.html"
-        image: portfolio/graphic-design/images/img2.jpg
-      - title: "Illustration"
-        link: "illustration.html"
-        image: portfolio/illustration/images/img1.jpg
-      - title: "Packaging"
-        link: "packaging-design.html"
-        image: portfolio/packaging-design/images/img1.jpg
-      - title: "Stylist"
-        link: "stylist.html"
-        image: portfolio/stylist/images/img1.jpg
-      - title: "Textile"
-        link: "textile-design.html"
-        image: portfolio/textile-design/images/img1.jpg
+  - type: carousel
+    items:
+      - src: portfolio/brand-identity/images/img3.jpg
+        alt: "Brand Identity"
+      - src: portfolio/graphic-design/images/img2.jpg
+        alt: "Graphic Design"
+      - src: portfolio/illustration/images/img1.jpg
+        alt: "Illustration"
+      - src: portfolio/packaging-design/images/img1.jpg
+        alt: "Packaging"
+      - src: portfolio/stylist/images/img1.jpg
+        alt: "Stylist"
+      - src: portfolio/textile-design/images/img1.jpg
+        alt: "Textile"
 ---
 
 <section class="cta">

--- a/script.js
+++ b/script.js
@@ -110,6 +110,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  // Simple image carousel
+  const carousel = document.querySelector('.carousel');
+  if (carousel) {
+    const slides = carousel.querySelectorAll('img');
+    let idx = 0;
+    slides.forEach((img, i) => {
+      img.style.display = i === 0 ? 'block' : 'none';
+      img.loading = 'lazy';
+    });
+    if (slides.length > 1) {
+      setInterval(() => {
+        slides[idx].style.display = 'none';
+        idx = (idx + 1) % slides.length;
+        slides[idx].style.display = 'block';
+      }, 3000);
+    }
+  }
+
   // ---- Bind ALL lightbox triggers on the page ----
   wireTriggers('.lightbox-trigger');
 


### PR DESCRIPTION
## Summary
- introduce simple JS-powered image carousel
- render carousel sections in layout when provided
- configure home page front matter with carousel images

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa1fb09488321aad0e9388198bc76