### PR TITLE
Add storytelling opener with scroll-snapping chapters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maria Uys – Home</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header id="topbar" class="topbar" role="banner">
+    <span class="logo">Maria Uys</span>
+    <button class="hamburger" aria-label="Open menu">☰</button>
+  </header>
+
+  <section id="opener" class="vh" aria-labelledby="opener-title">
+    <svg viewBox="0 0 100 100" class="morph" aria-hidden="true">
+      <path id="morphPath" d="M50 0 L100 100 L0 100 Z"></path>
+    </svg>
+    <div class="opener-content">
+      <h1 id="opener-title" class="line">Adventure Awaits</h1>
+      <p class="line">Discover stories of creativity.</p>
+      <p class="line">Scroll to begin the journey.</p>
+      <button id="enter" class="cta">Enter</button>
+    </div>
+  </section>
+
+  <main id="chapters" tabindex="-1">
+    <section class="chapter light" id="chapter-1">
+      <h2>Chapter One</h2>
+      <p class="subtitle">A glimpse of design</p>
+      <img src="https://via.placeholder.com/800x600" width="800" height="600" loading="lazy" alt="Sample design" class="parallax" data-speed="0.2" />
+      <a href="gallery1.html" class="btn">View Gallery</a>
+    </section>
+
+    <section class="chapter dark" id="chapter-2">
+      <h2>Chapter Two</h2>
+      <p class="subtitle">Visual stories</p>
+      <img src="https://via.placeholder.com/800x600" width="800" height="600" loading="lazy" alt="Sample visuals" class="parallax" data-speed="0.2" />
+      <a href="gallery2.html" class="btn">View Gallery</a>
+    </section>
+
+    <section class="chapter light" id="chapter-3">
+      <h2>Chapter Three</h2>
+      <p class="subtitle">Colorful moments</p>
+      <img src="https://via.placeholder.com/800x600" width="800" height="600" loading="lazy" alt="Colorful sample" class="parallax" data-speed="0.2" />
+      <a href="gallery3.html" class="btn">View Gallery</a>
+    </section>
+
+    <section class="chapter dark" id="chapter-4">
+      <h2>Chapter Four</h2>
+      <p class="subtitle">Textures and forms</p>
+      <img src="https://via.placeholder.com/800x600" width="800" height="600" loading="lazy" alt="Texture sample" class="parallax" data-speed="0.2" />
+      <a href="gallery4.html" class="btn">View Gallery</a>
+    </section>
+
+    <button class="arrow prev" aria-label="Previous chapter">&#8592;</button>
+    <button class="arrow next" aria-label="Next chapter">&#8594;</button>
+    <nav id="progress" aria-label="Chapter navigation">
+      <button aria-label="Go to chapter 1"></button>
+      <button aria-label="Go to chapter 2"></button>
+      <button aria-label="Go to chapter 3"></button>
+      <button aria-label="Go to chapter 4"></button>
+    </nav>
+  </main>
+
+  <script src="main.js" defer></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,81 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const opener = document.getElementById('opener');
+  requestAnimationFrame(() => opener.classList.add('animate'));
+
+  const enter = document.getElementById('enter');
+  const chaptersEl = document.getElementById('chapters');
+  const topbar = document.getElementById('topbar');
+
+  const gotoChapters = () => chaptersEl.scrollIntoView({ behavior: 'smooth' });
+  enter.addEventListener('click', gotoChapters);
+  window.addEventListener('wheel', function onFirstScroll() {
+    gotoChapters();
+    window.removeEventListener('wheel', onFirstScroll);
+  }, { once: true, passive: true });
+
+  const chapters = [...document.querySelectorAll('.chapter')];
+  const dots = [...document.querySelectorAll('#progress button')];
+  const prev = document.querySelector('.arrow.prev');
+  const next = document.querySelector('.arrow.next');
+  let current = 0;
+
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        current = chapters.indexOf(entry.target);
+        updateNav();
+      }
+    });
+  }, { threshold: 0.6 });
+
+  chapters.forEach((ch, i) => {
+    io.observe(ch);
+    const img = ch.querySelector('img');
+    if (img) {
+      img.decode().then(() => img.classList.add('loaded')).catch(() => img.classList.add('loaded'));
+    }
+  });
+
+  function updateNav() {
+    dots.forEach((dot, i) => {
+      dot.classList.toggle('active', i === current);
+      dot.setAttribute('aria-current', i === current ? 'true' : 'false');
+    });
+    prev.disabled = current === 0;
+    next.disabled = current === chapters.length - 1;
+    const isDark = chapters[current].classList.contains('dark');
+    topbar.classList.toggle('dark', isDark);
+  }
+
+  const scrollToIndex = (i) => {
+    if (i >= 0 && i < chapters.length) {
+      chapters[i].scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  prev.addEventListener('click', () => scrollToIndex(current - 1));
+  next.addEventListener('click', () => scrollToIndex(current + 1));
+  dots.forEach((dot, i) => dot.addEventListener('click', () => scrollToIndex(i)));
+
+  window.addEventListener('keydown', (e) => {
+    if (['ArrowDown', 'ArrowRight'].includes(e.key)) {
+      e.preventDefault();
+      scrollToIndex(current + 1);
+    } else if (['ArrowUp', 'ArrowLeft'].includes(e.key)) {
+      e.preventDefault();
+      scrollToIndex(current - 1);
+    }
+  });
+
+  const prefersReduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const parallaxEls = document.querySelectorAll('.parallax');
+  if (!prefersReduce && window.innerWidth > 768) {
+    window.addEventListener('scroll', () => {
+      const y = window.scrollY;
+      parallaxEls.forEach(el => {
+        const speed = parseFloat(el.dataset.speed) || 0.2;
+        el.style.setProperty('--offset', `${y * speed * -1}px`);
+      });
+    }, { passive: true });
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,142 @@
+:root {
+  --bg: #ffffff;
+  --text: #111111;
+  --accent: #ff6699;
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+html, body {
+  height: 100%;
+  margin: 0;
+  scroll-behavior: smooth;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Arial, sans-serif;
+}
+
+.vh { min-height: 100svh; }
+
+/* Topbar */
+.topbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: rgba(255,255,255,0.8);
+  backdrop-filter: blur(5px);
+  z-index: 10;
+}
+.topbar.dark {
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+}
+.topbar.dark .hamburger,
+.topbar.dark .logo { color: #fff; }
+
+/* Opener */
+#opener {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  overflow: hidden;
+}
+#opener svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+#morphPath {
+  fill: var(--accent);
+  animation: morphShapes 8s var(--ease) infinite;
+}
+.opener-content { position: relative; z-index: 1; }
+.line { opacity: 0; transform: translateY(0.5rem); }
+.cta { opacity: 0; transform: translateY(0.5rem); }
+#opener.animate .line { animation: fadeUp 1s var(--ease) forwards; }
+#opener.animate .line:nth-of-type(1) { animation-delay: 0.4s; }
+#opener.animate .line:nth-of-type(2) { animation-delay: 0.6s; }
+#opener.animate .cta { animation: fadeUp 1s var(--ease) forwards; animation-delay: 0.8s; }
+
+@keyframes fadeUp {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes morphShapes {
+  0% { d: path('M50 0 L100 100 L0 100 Z'); }
+  50% { d: path('M0 0 L100 0 L50 100 Z'); }
+  100% { d: path('M50 0 L100 100 L0 100 Z'); }
+}
+
+/* Chapters */
+#chapters { scroll-snap-type: y mandatory; }
+.chapter {
+  scroll-snap-align: start;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+.chapter img {
+  max-width: 80%;
+  height: auto;
+  opacity: 0;
+  transition: opacity 0.5s var(--ease);
+}
+.chapter img.loaded { opacity: 1; }
+.chapter.dark { background: #111; color: #fff; }
+.chapter.light { background: #fafafa; }
+
+/* Navigation */
+.arrow {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  font-size: 2rem;
+  padding: 1rem;
+  cursor: pointer;
+  color: inherit;
+  z-index: 5;
+}
+.arrow.prev { left: 0.5rem; }
+.arrow.next { right: 0.5rem; }
+.arrow:disabled { opacity: 0.3; cursor: not-allowed; }
+@media (max-width: 600px) { .arrow { display: none; } }
+
+#progress {
+  position: fixed;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 5;
+}
+#progress button {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  background: transparent;
+}
+#progress button.active { background: currentColor; }
+#progress button:focus { outline: 2px solid var(--accent); }
+
+/* Parallax */
+.parallax { transform: translateY(var(--offset, 0)); transition: transform 0.2s var(--ease); }
+
+@media (prefers-reduced-motion: reduce) {
+  #morphPath { animation: none; }
+  #opener.animate .line,
+  #opener.animate .cta { animation: none; opacity: 1; transform: none; }
+  .parallax { transform: none !important; }
+}


### PR DESCRIPTION
## Summary
- Add full-viewport storytelling opener with morphing SVG and CTA
- Introduce scroll-snapping chapter panels with arrow and dot navigation
- Implement intersection observer logic, keyboard support, and parallax fallbacks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a04602a894832180123ec00ccf4516