### PR TITLE
Add desktop navigation and responsive topbar

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -11,6 +11,25 @@
   <div class="topbar">
     <button class="hamburger" type="button" aria-label="Open menu">&#9776;</button>
     <div class="logo"><a href="/index.html">MU</a></div>
+    <nav class="desktop-menu">
+      <ul>
+        <li><a href="/index.html">About</a></li>
+        <li class="portfolio-toggle">
+          <a href="#">Portfolio</a>
+          <ul class="portfolio-sub">
+            <li><a href="/brand-identity.html">Brand Identity</a></li>
+            <li><a href="/graphic-design.html">Graphic Design</a></li>
+            <li><a href="/illustration.html">Illustration</a></li>
+            <li><a href="/packaging-design.html">Packaging</a></li>
+            <li><a href="/stylist.html">Stylist</a></li>
+            <li><a href="/textile-design.html">Textile</a></li>
+          </ul>
+        </li>
+        <li><a href="/features.html">Features</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li><a href="/cv.html" class="cv-label">CV</a></li>
+      </ul>
+    </nav>
   </div>
   <nav id="mobileMenu" class="slideout">
     <button class="close-btn" type="button" aria-label="Close menu">×</button>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,25 @@
   <div class="topbar">
     <button class="hamburger" type="button" aria-label="Open menu">&#9776;</button>
     <div class="logo"><a href="/index.html">MU</a></div>
+    <nav class="desktop-menu">
+      <ul>
+        <li><a href="/index.html">About</a></li>
+        <li class="portfolio-toggle">
+          <a href="#">Portfolio</a>
+          <ul class="portfolio-sub">
+            <li><a href="/brand-identity.html">Brand Identity</a></li>
+            <li><a href="/graphic-design.html">Graphic Design</a></li>
+            <li><a href="/illustration.html">Illustration</a></li>
+            <li><a href="/packaging-design.html">Packaging</a></li>
+            <li><a href="/stylist.html">Stylist</a></li>
+            <li><a href="/textile-design.html">Textile</a></li>
+          </ul>
+        </li>
+        <li><a href="/features.html">Features</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li><a href="/cv.html" class="cv-label">CV</a></li>
+      </ul>
+    </nav>
   </div>
   <nav id="mobileMenu" class="slideout">
     <button class="close-btn" type="button" aria-label="Close menu">×</button>

--- a/styles.css
+++ b/styles.css
@@ -99,7 +99,7 @@ body.home {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 1001;
+  z-index: 1100;
 }
 
 
@@ -124,6 +124,74 @@ body.home {
   font-weight: bold;
   text-decoration: none;
   color: #333;
+}
+
+/* Desktop nav (hidden by default, shown on larger screens) */
+.desktop-menu {
+  display: none;
+  margin-left: auto;
+}
+
+.desktop-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.desktop-menu li {
+  position: relative;
+}
+
+.desktop-menu a {
+  text-decoration: none;
+  color: #444;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+  background: linear-gradient(to right, #ffd6e0, #e8d6ff);
+  border-radius: 2rem;
+  display: block;
+  transition: filter 0.3s ease;
+}
+
+.desktop-menu a:hover {
+  filter: brightness(0.95);
+}
+
+.desktop-menu .portfolio-sub {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 0;
+  border-radius: 0.5rem;
+  list-style: none;
+  z-index: 1200;
+}
+
+.desktop-menu li:hover > .portfolio-sub {
+  display: block;
+}
+
+.desktop-menu .portfolio-sub li a {
+  background: none;
+  padding: 0.4rem 1rem;
+  border-radius: 0;
+}
+
+.desktop-menu .portfolio-sub li a:hover {
+  background: #f0f0f0;
+  filter: none;
+}
+
+@media screen and (min-width: 769px) {
+  .hamburger { display: none; }
+  #mobileMenu { display: none; }
+  #overlay { display: none !important; }
+  .desktop-menu { display: block; }
 }
 
 /* Sidebar */


### PR DESCRIPTION
## Summary
- Add desktop navigation menu to top bar and layout
- Implement responsive styles to show full menu on larger screens while retaining hamburger on mobile
- Maintain topbar above scroll container using higher z-index

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a058ca82e883218d8ebca60152f0a7