### PR TITLE
Prevent mobile menu from closing before link navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -100,6 +100,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const menu = document.getElementById('mobileMenu');
     const overlay = document.getElementById('overlay');
     const ham = document.querySelector('button.hamburger');
+    // Let anchor clicks inside the menu navigate before closing
+    if (menu.contains(e.target) && e.target.closest('a')) return;
     if (!menu.contains(e.target) && !ham.contains(e.target)) {
       menu.classList.remove('open'); overlay.style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- Ensure document click handler ignores anchor clicks inside the mobile menu so navigation occurs

## Testing
- `npm run build`
- Attempted Puppeteer navigation test *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a794ce88321bbe485c32585eca5