### PR TITLE
Add missing portfolio sections and link images to pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,21 +61,54 @@
     <section class="chapter" id="chapter-brand">
       <h2>Brand Identity</h2>
       <div class="gallery">
-        <img src="portfolio/brand-identity/images/img3.jpg" alt="Brand Identity sample" class="lightbox-trigger">
+        <a href="/brand-identity.html">
+          <img src="portfolio/brand-identity/images/img3.jpg" alt="Brand Identity sample">
+        </a>
       </div>
     </section>
 
     <section class="chapter" id="chapter-graphic">
       <h2>Graphic Design</h2>
       <div class="gallery">
-        <img src="portfolio/graphic-design/images/img2.jpg" alt="Graphic Design sample" class="lightbox-trigger">
+        <a href="/graphic-design.html">
+          <img src="portfolio/graphic-design/images/img2.jpg" alt="Graphic Design sample">
+        </a>
       </div>
     </section>
 
     <section class="chapter" id="chapter-illustration">
       <h2>Illustration</h2>
       <div class="gallery">
-        <img src="portfolio/illustration/images/img1.jpg" alt="Illustration sample" class="lightbox-trigger">
+        <a href="/illustration.html">
+          <img src="portfolio/illustration/images/img1.jpg" alt="Illustration sample">
+        </a>
+      </div>
+    </section>
+
+    <section class="chapter" id="chapter-packaging">
+      <h2>Packaging</h2>
+      <div class="gallery">
+        <a href="/packaging-design.html">
+          <img src="portfolio/packaging-design/images/img1.jpg" alt="Packaging Design sample">
+        </a>
+      </div>
+    </section>
+
+    <section class="chapter" id="chapter-stylist">
+      <h2>Stylist</h2>
+      <div class="gallery">
+        <a href="/stylist.html">
+          <img src="portfolio/stylist/images/img1.jpg" alt="Stylist sample">
+        </a>
+      </div>
+    </section>
+
+    <section class="chapter" id="chapter-textile">
+      <h2>Textile</h2>
+      <div class="gallery">
+        <a href="/textile-design.html">
+          <img src="portfolio/textile-design/images/img1.jpg" alt="Textile Design sample">
+        </a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Add packaging, stylist, and textile chapters to homepage scroll
- Wrap all portfolio thumbnails in links to their respective pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a05d80cbe08321a241804f4af5f30b