### PR TITLE
feat: convert home to horizontal banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,6 @@
   <main id="scrollContainer">
     <section class="opener">
       <div class="hero-bg"></div>
-      <button id="enter" class="btn">Enter</button>
     </section>
 
     <section class="chapter" id="chapter-brand">

--- a/main.js
+++ b/main.js
@@ -24,25 +24,26 @@ document.addEventListener('DOMContentLoaded', () => {
     let chapterIndex = 0;
 
     function scrollToChapter(i) {
-      sections[i].scrollIntoView({ behavior: 'smooth' });
+      sections[i].scrollIntoView({ behavior: 'smooth', inline: 'start' });
       chapterIndex = i;
     }
 
     scrollContainer.addEventListener('scroll', () => {
-      chapterIndex = Math.round(scrollContainer.scrollTop / window.innerHeight);
+      chapterIndex = Math.round(scrollContainer.scrollLeft / window.innerWidth);
     });
 
     document.addEventListener('keydown', e => {
-      if (e.key === 'ArrowDown' && chapterIndex < sections.length - 1) scrollToChapter(chapterIndex + 1);
-      if (e.key === 'ArrowUp' && chapterIndex > 0) scrollToChapter(chapterIndex - 1);
+      if (e.key === 'ArrowRight' && chapterIndex < sections.length - 1) scrollToChapter(chapterIndex + 1);
+      if (e.key === 'ArrowLeft' && chapterIndex > 0) scrollToChapter(chapterIndex - 1);
     });
 
-    const enterBtn = document.getElementById('enter');
-    enterBtn?.addEventListener('click', () => scrollToChapter(1));
-
-    window.addEventListener('wheel', () => {
-      if (chapterIndex === 0) scrollToChapter(1);
-    }, { once: true });
+    const fadeIO = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('active');
+        else entry.target.classList.remove('active');
+      });
+    }, { root: scrollContainer, threshold: 0.6 });
+    sections.forEach(sec => fadeIO.observe(sec));
   }
 
 

--- a/styles.css
+++ b/styles.css
@@ -29,21 +29,23 @@ body {
 }
 
 body.home {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 #scrollContainer {
-  height: 100vh;
-  overflow-y: scroll;
-  scroll-snap-type: y mandatory;
-  scroll-padding-top: 4rem;
+  height: 65vh;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  display: flex;
   padding: 0;
   position: relative;
   z-index: 1;
 }
 
 .opener, .chapter {
-  height: 100vh;
+  flex: 0 0 100%;
+  height: 100%;
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
@@ -51,11 +53,16 @@ body.home {
   justify-content: center;
   text-align: center;
   padding: 2rem;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.opener.active, .chapter.active {
+  opacity: 1;
 }
 
 .opener {
   position: relative;
-  height: 100vh;
   background-size: cover;
   background-position: center;
 }
@@ -70,10 +77,6 @@ body.home {
   z-index: -1;
 }
 
-.opener .btn {
-  margin-top: 2rem;
-  z-index: 1;
-}
 
 .chapter .gallery {
   display: flex;


### PR DESCRIPTION
## Summary
- replace vertical home scroller with horizontal banner that snaps and fades between sections
- set banner height to 65% of viewport and remove enter button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06037cf048321b7b990a802a20a35